### PR TITLE
remove protocol relative urls

### DIFF
--- a/lazyYT.js
+++ b/lazyYT.js
@@ -122,7 +122,7 @@
         $thumb = $el.find('.ytp-thumbnail').on('click', function (e) {
             e.preventDefault();
             if (!$el.hasClass(settings.video_loaded_class)) {
-                $el.html('<iframe src="//www.youtube.com/embed/' + id + '?' + youtube_parameters + '&autoplay=1" frameborder="0" allowfullscreen></iframe>')
+                $el.html('<iframe src="https://www.youtube.com/embed/' + id + '?' + youtube_parameters + '&autoplay=1" frameborder="0" allowfullscreen></iframe>')
                     .addClass(settings.video_loaded_class);
 
                 // execute callback


### PR DESCRIPTION
Best practice appears to be no more protocol relative urls. Paul Irish [says](http://www.paulirish.com/2010/the-protocol-relative-url/) use https for everything, and the embed code YouTube provides today is https as well.
